### PR TITLE
bugfix: handle content-type headers with charset

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,8 @@ function LdpStore (rdf, options) {
         var contentType = self.defaultParser;
 
         // ...if content-type is not given or unknown
-        if ('content-type' in headers && headers['content-type'] in self.parsers) {
-          contentType = headers['content-type'];
+        if ('content-type' in headers && headers['content-type'].split(';')[0] in self.parsers) {
+          contentType = headers['content-type'].split(';')[0];
         }
         
         // and override if set in options


### PR DESCRIPTION
If I'm not mistaken, the spec allows for charset in the content-type, because it is defined in the http spec.
